### PR TITLE
knex connection 初始化配置需要添加 timezone 属性

### DIFF
--- a/lib/mysql/index.js
+++ b/lib/mysql/index.js
@@ -9,6 +9,6 @@ module.exports = require('knex')({
         password: configs.mysql.pass,
         database: configs.mysql.db,
         charset: configs.mysql.char,
-        timezone: 'UTC'
+        timezone: configs.mysql.timezone || 'UTC'
     }
 })

--- a/lib/mysql/index.js
+++ b/lib/mysql/index.js
@@ -8,6 +8,7 @@ module.exports = require('knex')({
         user: configs.mysql.user,
         password: configs.mysql.pass,
         database: configs.mysql.db,
-        charset: configs.mysql.char
+        charset: configs.mysql.char,
+        timezone: 'UTC'
     }
 })


### PR DESCRIPTION
在 lib/mysql/index.js connection 初始化中添加属性：
    timezone: configs.mysql.timezone || 'UTC'
    
如果不添加这个属性，knex 在返回 timestamp 类型的数据时会回退8个小时，可能导致业务逻辑错误。
我也曾经尝试设置这个值为 CST，但是 knex 只识别这个值为美国中部时间而不是中国标准时间。
不过从目前我这边的测试结果看来，设为 UTC 时的 timestamp 返回值与数据库内容一致，功能正确。
目前这种修改方法也许还要提醒用户在 wafer2-startup 里留意这个配置，比如ta要使用另外的时区，如果用户没有配置，则使用UTC。
knex 的官方文档中压根没有提过可以添加timezone这个属性，我是在 stackoverflow 里找到的。这样修改解决了我的程序中的问题，但是否正确，还请腾讯官方决定。谢谢！