### PR TITLE
feat: 上传文件返回链接修改为新接口

### DIFF
--- a/lib/upload/index.js
+++ b/lib/upload/index.js
@@ -8,18 +8,6 @@ const CosSdk = require('cos-nodejs-sdk-v5')
 const ERRORS = require('../constants').ERRORS
 const config = require('../../config')
 
-const regionMap = {
-    'ap-beijing-1': 'tj',
-    'ap-beijing': 'bj',
-    'ap-shanghai': 'sh',
-    'ap-guangzhou': 'gz',
-    'ap-chengdu': 'cd',
-    'ap-singapore': 'sgp',
-    'ap-hongkong': 'hk',
-    'na-toronto': 'ca',
-    'eu-frankfurt': 'ger'
-}
-
 /**
  * 对象上传 API
  * @param {express request} req
@@ -143,7 +131,7 @@ module.exports = (req) => {
                     }
 
                     resolve({
-                        imgUrl: `http://${config.cos.fileBucket}-${config.qcloudAppId}.cos${regionMap[config.cos.region]}.myqcloud.com/${uploadFolder}${imgKey}`,
+                        imgUrl: `http://${config.cos.fileBucket}-${config.qcloudAppId}.cos.${config.cos.region}.myqcloud.com/${uploadFolder}${imgKey}`,
                         size: imageFile.size,
                         mimeType: resultType.mime,
                         name: imgKey,


### PR DESCRIPTION
旧接口 example-1234567890.cosgz.myqcloud.com 无法正常访问，建议修改为新接口：example-1234567890.cos.ap-guangzhou.myqcloud.com

[参考文档](https://cloud.tencent.com/document/product/436/6224)