### PR TITLE
fix TypeError because of missing parameters

### DIFF
--- a/lib/upload/index.js
+++ b/lib/upload/index.js
@@ -106,7 +106,7 @@ module.exports = (req) => {
                 if (err) {
                     reject(err)
                     // remove uploaded file
-                    fs.unlink(srcpath)
+                    fs.unlinkSync(srcpath)
                 }
 
                 // 检查提供的 Bucket 是否存在
@@ -123,7 +123,7 @@ module.exports = (req) => {
                         if (err) {
                             reject(err)
                             // remove uploaded file
-                            fs.unlink(srcpath)
+                            fs.unlinkSync(srcpath)
                         } else {
                             resolve()
                         }
@@ -139,7 +139,7 @@ module.exports = (req) => {
                     if (err) {
                         reject(err)
                         // remove uploaded file
-                        fs.unlink(srcpath)
+                        fs.unlinkSync(srcpath)
                     }
 
                     resolve({
@@ -156,7 +156,7 @@ module.exports = (req) => {
                     })
 
                     // remove uploaded file
-                    fs.unlink(srcpath)
+                    fs.unlinkSync(srcpath)
                 })
             })
         })


### PR DESCRIPTION
After node v10.0.0  , `fs.unlink` The callback parameter is no longer optional. Not passing it will throw a TypeError at runtime. use `fs.unlinkSync` instead.


